### PR TITLE
corrected 'o' -> 'ø' in instances like 'Kjobenhavn', 'kjobe' and 'Kjo…

### DIFF
--- a/texts/heibergpa01val.xml
+++ b/texts/heibergpa01val.xml
@@ -794,7 +794,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 	      Highwayman. Mig gjemte hun med al Omhyggelighed i en Sprække i
 	      Sengen, hvor hun kunde trodse ikke alene hendes Mands Eftersøgen,
 	      men endogsaa Tyves og Røveres, ja selv Toldbetjenteres <note anchored="true" xml:id="idm140167182579488">
-                                    <hi rend="italics" xml:id="idm140167182579088"><!--<emph>-->Highwayman<!--</emph>--></hi> (engelsk), Røver. - <hi rend="italics" xml:id="idm140167182577984"><!--<emph>-->Wandsbeck<!--</emph>--></hi>, Tallotteriet blev trukket i Wandsbeck og Kjobenhavn.</note>
+                                    <hi rend="italics" xml:id="idm140167182579088"><!--<emph>-->Highwayman<!--</emph>--></hi> (engelsk), Røver. - <hi rend="italics" xml:id="idm140167182577984"><!--<emph>-->Wandsbeck<!--</emph>--></hi>, Tallotteriet blev trukket i Wandsbeck og Kjøbenhavn.</note>
                                 <pb n="14" facs="adl/heibergpa/heibergpa01/heibergpa1014" xml:id="idm140167182576784"/> inkvisitoriske Øjne.
 	      "Vær velkommen," sagde hun, "du har
 	      rigtig betalt mig min Selvfornægtelse i Aften. For de fem Mark
@@ -1541,7 +1541,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 		dig denne Rettighed med. Saa længe som Forordninger, Forbud,
 		Lavsartikler og andet mere forbyder mig at fortjene mit Brod paa
 		en lovlig Maade med det Haandværk, som jeg har lært, og saa
-		længe jeg mangler de fornødne Penge for at tilkjobe mig min
+		længe jeg mangler de fornødne Penge for at tilkjøbe mig min
 		Tilladelse, saa længe maa jeg enten sulte eller og ernære mig
 		med ulovlige Midler.</p>
                                 <note anchored="true" xml:id="idm140167182429104">
@@ -1976,7 +1976,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 	      har til fælles med Poeten - nøder ham til at drive
 	      Smughandel; det kan i sig selv dog <hi rend="italics" xml:id="idm140167182323376"><!--<emph>-->ikke<!--</emph>--></hi> være Regeringen ligegyldigt, men den kan heller ikke ved de
 	      utallige forefaldende Lejligheder undersøge Drivefjederen dertil,
-	      allerhelst da Smughandelen er Kjobmandstandens Arvesynd; og naar
+	      allerhelst da Smughandelen er Kjøbmandstandens Arvesynd; og naar
 	      Lovgiveren sinder det fornødent i denne Henseende at indskrænke den
 	      handlendes Frihed, saa har han uimodsigeligen Rettighed dertil, og
 	      at han ogsaa benytter sig deraf, det vise de utallige for det meste
@@ -2367,7 +2367,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 	      aldeles stridende imod den, som han tilforn havde lært, men uden at
 	      gruble meget derover, satte han større Tro til en levende Principals
 	      end til en død Morten Luthers Infallibilitet. Da denne <pb n="60" facs="adl/heibergpa/heibergpa01/heibergpa1060" xml:id="idm140167182240560"/> Katekismus kan være i mange Punkter
-	      tjenlig for andre end netop Kjobmandsstanden, saa skal jeg til
+	      tjenlig for andre end netop Kjøbmandsstanden, saa skal jeg til
 	      Slutning lade den aftrykke, alle dem til Lærdom og Undervisning, som
 	      samme kunne behøve.</p>
                             <p xml:id="idm140167182239216">Det forste, man med al Magt søgte at indprente ham, var den store
@@ -2500,7 +2500,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 		Skyld har jeg dog holdt for, at den burde til offentlig Brug
 		udgives, siden man i disse tolerante Tider har Lov til at
 		bekjende sig til, hvad Tro man vil Den er ganske authentiqve og
-		fundet i en Kjobmands Arkiv, der er saa aldeles orthodoxe, at
+		fundet i en Kjøbmands Arkiv, der er saa aldeles orthodoxe, at
 		han endogsaa meget slet betaler de Folk, der hjælpe ham til at
 		formere hans Rigdom, med mindre de kan bevise, at de har gjort
 		det ved Skjælmstykker og ulovlige Midler Skulde denne
@@ -2535,7 +2535,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
                                 </div>
                                 <div xml:id="idm140167182206304">
                                     <head xml:id="idm140167182206048">Det andet Bud.</head>
-                                    <p xml:id="idm140167182205664">Du skal ikke bruge din Kjobmands-Gud forfængeligen, men vel i
+                                    <p xml:id="idm140167182205664">Du skal ikke bruge din Kjøbmands-Gud forfængeligen, men vel i
 		  fornødne Tilfælde det højeste Væsen, som du dog, enten <pb n="65" facs="adl/heibergpa/heibergpa01/heibergpa1065" xml:id="idm140167182205120"/> du er en Kristen, Jøde,
 		  Tyrk eller Hedning, maa nødeS til at tro.</p>
                                     <p xml:id="idm140167182204048">Det er: Du skal frygte og elske dine Penge, og ikke bruge dem
@@ -3826,7 +3826,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 	      identisk med Æventyreren Mortzini, der i Tyskland var bleven
 	      overbevist om Plagiat og adskillige andre graverende Ting.</note>
                             <pb n="102" facs="adl/heibergpa/heibergpa01/heibergpa1102" xml:id="idm140167181923696"/>
-                            <p xml:id="idm140167181922960">Strax efter, at han var ankommen til Kjobehhavn, lod han offentlig
+                            <p xml:id="idm140167181922960">Strax efter, at han var ankommen til Kjøbenhavn, lod han offentlig
 	      bekjendtgjøre, at han vilde give Undervisning i mangfoldige
 	      Videnskaber og Sprog, hvoriblandt ogsaa det russiske befandtes, som
 	      han foregav sig at forstaa af Grunden, siden han i tolv Aar havde
@@ -7017,7 +7017,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 		Oversætteren har været heldigst med, men de har ogsaa kostet ham
 		mest Umage. Og overalt besidder Hr. Baggesen alt for mange
 		Fortjenester til, at han skulde tro, at hans Holger Danske kunde
-		i Skjonheder og Ynde sammenlignes med Wielands Oberon.</p>
+		i Skjønheder og Ynde sammenlignes med Wielands Oberon.</p>
                             </sp>
                             <sp xml:id="idm140167181132000">
                                 <speaker xml:id="idm140167181131744">
@@ -7390,7 +7390,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 	      er oversat, dog ikke af Junkeren selv, hvilket jeg finder fornødent,
 	      for visse Aarsagers Skyld, at erklære, med dette Tillæg, at Junkeren
 	      ikke har sin største Styrke i Sprogene, da han næppe engang vilde
-	      være i Stand til at oversætte os Kjobmager-Gade paa Latin, og
+	      være i Stand til at oversætte os Kjøbmager-Gade paa Latin, og
 	      følgeligen i Sprogkundskab staar overordentlig langt efter den
 	      mægtige Hr. Georgius Johannes Thomsenius Sacro-Sancti Ministerii
 	      Candidatus, in platea mercatoria parva habitans, der i et
@@ -9608,7 +9608,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
                             <p xml:id="idm140167180571360">"Jeg har set adskillige af denne Art," svarede
 	    Kaptejnen, "thi denne Mand er vist ikke deu eneste
 	    kristne Aagerkarl og Blodigle, som ligger for Anker inden
-	    Kjobenhavns Volde. Jeg har set Folk af høj Rang og Stand med
+	    Kjøbenhavns Volde. Jeg har set Folk af høj Rang og Stand med
 	    Port-Epé i Kaarden at drive denne Negotie, og derved at vanære den
 	    Stand, hvis Hæder det skal være at se Fjendens og ikke Landsmænds
 	    Blod. Men, kan De give mig nogle Kjendetegn paa denne Mand og hans
@@ -9947,7 +9947,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 	    "om De ikke vilde skille mig ved den Kalv? Jeg skal lade
 	    den for Halvparten af, hvad den koster mig, men det var alt for
 	    tungt, om jeg skulde tabe alt. Jeg har haft den hængende hele Dagen
-	    i Slagterboden, men ingen vil kjobe den, thi de siger, at de kan se,
+	    i Slagterboden, men ingen vil kjøbe den, thi de siger, at de kan se,
 	    det ikke hænger rigtig sammen med den. Nu, paa et Spisekvarter er
 	    man ikke saa nøjeregnende, og naar der kommer en nogenlunde Sauce
 	    paa, saa glider Kjødet nok ned hos Gjæsterne."</p>
@@ -10254,7 +10254,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 	    Aftenen ødelægge, ved at bære de helligste Navne ideligen paa
 	    Tungen, saa forsærdedes han og skyndede sig bort, da han hellere
 	    vilde, at han selv tillige med hans Kone skulde blive gjennemvaade
-	    af vor Herres Regn, end kjobe sig tørre Klæder paa saa stor
+	    af vor Herres Regn, end kjøbe sig tørre Klæder paa saa stor
 	    Bekostning for hans Øjne og Øren. "Herre Gud!"
 	    sagde han til sin Kone, da han kom ud, "næppe kan jeg af
 	    en hel Uges Stræbsomhed henlægge en Rigsort for at fornøje og
@@ -10376,7 +10376,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 	    Venner og Patroner, ere overladte til sig selv. De Forbrydelser, som
 	    en Mand af den ringe Stand eller Middelstanden kan begaa, ere
 	    sjælden skadelige uden i en lille Cirkel, naar derimod Ministerens
-	    Uredelighed, Skjodesløshed, Forsømmelse eller Egennytte ofte lægge
+	    Uredelighed, Skjødesløshed, Forsømmelse eller Egennytte ofte lægge
 	    Grund til hele Staters Undergang. Og hvor ofte ser ikke denne med
 	    Koldsindighed paa, at hin afstraffes for en Forbrydelse, som denne
 	    har be~ gaaet tusende Gange væire? Hvor ofte finder man ikke Aarsag
@@ -10745,7 +10745,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 	    have nogle Blanketter i Beredskab, hvorpaa de konfiskerede Nummere
 	    igjen kunde tegnes; og Lysten til at skrive Sottiser vilde snart
 	    forgaa de overgivne unge Herrer, naar de mærkede, at enhver kostede
-	    dem fra to Mark til en Rigsdaler. Den, der kjobte en Billet, havde
+	    dem fra to Mark til en Rigsdaler. Den, der kjøbte en Billet, havde
 	    jo Rettighed til at panse, at han fik en, som var umakuleret; og at
 	    Billetterne skulde komme lige saa umakulerede tilbage, derover burde
 	    holdes saa strængt, at Betjenterne ved Dorene skulde være ansvarlige
@@ -10937,7 +10937,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
                                 <p xml:id="idm140167180294816">Det skal jeg sige Dem. Politiet har sandelig saa meget at
 	      iagttage, ar det er Synd at paalægge dets Betjentere ny Pligter.
 	      Især gives der nok ingen større Slave i Hans Majestæts Riger og
-	      Lande end en Politimester i Kjobenhavn, der vil passe paa alt,
+	      Lande end en Politimester i Kjøbenhavn, der vil passe paa alt,
 	      hvad han bør. Hvad mig angaar, da vilde jeg meget tage i
 	      Betænkning at modtage denne Tjeneste, om jeg endog besad
 	      Duelighed til at foresstaa den, og den blev mig tilbudet. Det er
@@ -11008,11 +11008,11 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 	      Deres Forslag et Anstrøg deraf; og naar det kuns ser ud, som om
 	      De vilde økonomisere, saa skader det ikke, om man, efter nogle
 	      Aars Forløb, naar Deres Planer ere iværksatte, opdager, at De
-	      har ruineret Kongens Kasse i Steden for at spare paa den. Sna
+	      har ruineret Kongens Kasse i Steden for at spare paa den. Saa
 	      hedder det: Gjort Gjerning er ikke god at ændre; det er en
 	      Ulykke, som man lige saa lidet kunde formode, som man kunde
 	      indse, at en Blegdam, der for Kongens Penge blev anlagt ved
-	      Siden af en Smedje, hvor Stenkuis-Støven uden Ophør nedfalder,
+	      Siden af en Smedje, hvor Stenkuls-Støven uden Ophør nedfalder,
 	      skulde producere sorte Lærreder. Og i saadanne Tilfælde, hvor
 	      det ikke gjælder om andet end om Kongens Kasse, der har man saa
 	      stor Afsky for at bruge de tre Ord: Det er Løgn, at intet
@@ -11020,7 +11020,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 	      saadan Blegdam, om han endog foreviste de hvideste Lærreder, som
 	      han foregav at være blegede der.</p>
                             </sp>
-                            <p xml:id="idm140167180275760">Nu var Stuen fuld af Kjobere til Komedie-Billetter, hvorfore
+                            <p xml:id="idm140167180275760">Nu var Stuen fuld af Kjøbere til Komedie-Billetter, hvorfore
 	    Kassereren maatte ophøre med denne Samtale. Min Herre leverede mig
 	    til Kassereren, hvorimod han fik en <note anchored="true" xml:id="idm140167180275312">tis the curse of cervice
 	    o. s. v. Det er Tjenestens Forbandelse, at Forfremmelse sker
@@ -13906,7 +13906,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
                                     <note anchored="true" xml:id="idm140167179352048">Professor <hi rend="italics" xml:id="idm140167179351488"><!--<emph>-->Lars<!--</emph>--></hi> Lauritz, <hi rend="italics" xml:id="idm140167179350448"><!--<emph>-->Smith<!--</emph>--></hi>, se Noten S 121 - Joh. Bernh <hi rend="italics" xml:id="idm140167179349360"><!--<emph>-->Basedow<!--</emph>--></hi> 1723-1790, den bekjendte Pædagog, var fra
 	      1753-61 Professor i Sorø, Hollænderen <hi rend="italics" xml:id="idm140167179348144"><!--<emph>-->Joh Meursius<!--</emph>--></hi>, den bekjendte Historiker, ligesaa fra 1625 til sin
 	      Dod 1639, Fr Gabr <hi rend="italics" xml:id="idm140167179347040"><!--<emph>-->Resewitz<!--</emph>--></hi> (1725-1806) var fra 1767-74 Præst
-	      ved Petri Kirke i Kjobenhavn Chr Gottlieb <hi rend="italics" xml:id="idm140167179345840"><!--<emph>-->Kratzenstein<!--</emph>--></hi> (1723-1795) var fra 1753 Professor i Fysik i
+	      ved Petri Kirke i Kjøbenhavn Chr Gottlieb <hi rend="italics" xml:id="idm140167179345840"><!--<emph>-->Kratzenstein<!--</emph>--></hi> (1723-1795) var fra 1753 Professor i Fysik i
 	      Kjøbenhavn. Carsten <hi rend="italics" xml:id="idm140167179344656"><!--<emph>-->Niebuhr<!--</emph>--></hi>, den beromte Geograf (1733 til 1815). Johan Clemens
 	      <hi rend="italics" xml:id="idm140167179343568"><!--<emph>-->Tode<!--</emph>--></hi> (1736-1806), den bekjendte medicinske og
 	      æsthetiske Forfatter Joh Abraham Peter <hi rend="italics" xml:id="idm140167179342352"><!--<emph>-->Schultz<!--</emph>--></hi> (1717-1800) var fra (1787-1795)
@@ -14695,7 +14695,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
                                         <hi rend="italics" xml:id="idm140167179138720"><!--<emph>-->Sætterens<!--</emph>--></hi> Anm</bibl>
                                 </note>
                                 <note anchored="true" xml:id="idm140167179137424">F <hi rend="italics" xml:id="idm140167179136896"><!--<emph>-->Barfred<!--</emph>--></hi> forfattede en Mængde Pjecer om Ordningen af Forholdene ved
-	    Assurancekassen. - <hi rend="italics" xml:id="idm140167179135664"><!--<emph>-->En opmærksom Eftertanke<!--</emph>--></hi> for alle Gaard- og Husejere i Kjobenhavn, af en Patriot
+	    Assurancekassen. - <hi rend="italics" xml:id="idm140167179135664"><!--<emph>-->En opmærksom Eftertanke<!--</emph>--></hi> for alle Gaard- og Husejere i Kjøbenhavn, af en Patriot
 	    Kbh 1790</note>
                                 <pb n="345" facs="adl/heibergpa/heibergpa01/heibergpa1345" xml:id="idm140167179134400"/> Skæbne vilde just have det
 	    saaledes, at et lidet Hjørne af mig laa uden for Bordet og faldt
@@ -19629,7 +19629,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
                                     <hi rend="italics" xml:id="idm140167177607808"><!--<emph>-->Snydenstrup.<!--</emph>--></hi>
                                 </speaker>
                                 <p xml:id="idm140167177606672">Jo, for han gaar sikkert paa Frieri, det tror jeg, siden han vil
-	    kjobe Prætensioner; og mener du da, at han ikke hellere gav tre
+	    kjøbe Prætensioner; og mener du da, at han ikke hellere gav tre
 	    Guld-Ure bort, end at hans Kjæreste skulde faa denne Mistanke?
 	    - Men tyst! der kommer nogen paa Trappen. <stage type="mix" xml:id="idm140167177605872">(Han
 	    puster Lyset ud og leder Jonas hen bag en Stol i
@@ -21039,7 +21039,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 	    gjærne kan hænde sig - for jeg har just ikke mange af
 	    de Egenskaber, der skal gjøre Mandfolk behagelige hos det andet
 	    Kjøn, - saa vil <pb n="456" facs="adl/heibergpa/heibergpa01/heibergpa1456" xml:id="idm140167177086240"/>
-	    jeg, saa min Sjæl! ikke eje hende, endskjont jeg derfor ikke
+	    jeg, saa min Sjæl! ikke eje hende, endskjønt jeg derfor ikke
 	    skal lade være at holde af hende.</p>
                             </sp>
                             <sp xml:id="idm140167177085008">
@@ -21073,7 +21073,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 	    rettest at lade Præsten gjøre den. Men én Ting er der endnu, som
 	    staar mig for Hovedet: jeg har aldrig friet, og jeg tror, paa
 	    min Sjæl! ikke, at jeg kunde sige et Ord til hende i den
-	    Materie, skjont Kjæften ellers nok plejer at staa mig bi. Vil De
+	    Materie, skjønt Kjæften ellers nok plejer at staa mig bi. Vil De
 	    ikke paatage Dem Umagen for mig?</p>
                             </sp>
                             <sp xml:id="idm140167177075328">
@@ -21810,7 +21810,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
                                 <speaker xml:id="idm140167176824560">
                                     <hi rend="italics" xml:id="idm140167176824304"><!--<emph>-->Jonas<!--</emph>--></hi>
                                 </speaker>
-                                <stage type="mix" xml:id="idm140167176823168">(trækker sra Fader i Kjolen).</stage>
+                                <stage type="mix" xml:id="idm140167176823168">(trækker saa Fader i Kjolen).</stage>
                                 <p xml:id="idm140167176822464">O! lad os gaa.</p>
                             </sp>
                             <sp xml:id="idm140167176821952">
@@ -24570,7 +24570,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
                             <bibl xml:id="idm140167175867680">Marcellus i Shakspear's Hamlet.</bibl>
                         </epigraph>
                         <p xml:id="idm140167175867120">
-                            <hi rend="bold" xml:id="idm140167175866992">E</hi>t gammelt Ordsprog siger: "<hi rend="italics" xml:id="idm140167175866288"><!--<emph>-->Hvo som smører godt, han kjorer godt<!--</emph>--></hi>". Imidlertid, da dette Ordsprog for det meste tages i
+                            <hi rend="bold" xml:id="idm140167175866992">E</hi>t gammelt Ordsprog siger: "<hi rend="italics" xml:id="idm140167175866288"><!--<emph>-->Hvo som smører godt, han kjører godt<!--</emph>--></hi>". Imidlertid, da dette Ordsprog for det meste tages i
 							en Mening, hvori jeg paa dette Sted ikke vil have det taget, saa sinder
 							jeg det fornødent at forandre samme saaledes: "<hi rend="italics" xml:id="idm140167175864784"><!--<emph>-->Hvo som betaler vel, bliver vel betjent<!--</emph>--></hi>". Vist nok er det, at dette Ordsprog, saaledes udtrykt,
 							ikke alt for ofte holder Stik; men man kan dog vel sige med Sandhed, at
@@ -25190,7 +25190,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 							fradrages)*)....... 27,000<lb xml:id="idm140167175601536"/> 4) Leverancer og Arbejder af alle Slags,
 							til Brug for Direktoriet, (hvori dog er iberegnet deres Kontorer, samt
 							Transport af de Sager, der bruges til de nationale Fester, og som altsaa
-							ligeledes burde fradrages); Indkjob og Vedligeholdelse af deres Møbler
+							ligeledes burde fradrages); Indkjøb og Vedligeholdelse af deres Møbler
 							og andre Smaating.... 300,000<lb xml:id="idm140167175600640"/> 5) Den indvendige Lysning i deres
 								<note anchored="true" xml:id="idm140167175600320">*) De Summer, der burde fradrages i 3dje, 4de og 7de Poster,
 								maa jeg lade staa, da jeg ikke véd sammes specielle Beløb.</note>
@@ -25255,7 +25255,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
 							hører iblandt de Udgifter, der i monarkiske Stater bestrides af de til
 							saadant Brug særskilt henlagte Bygnings-Fonds. Enhver Konge har fri
 							Bolig i én eller flere offentlige Bygninger, der ere byggede eller
-							kjobte for Nationens Penge og altsaa tilhore Nationen. Direktoriets frie
+							kjøbte for Nationens Penge og altsaa tilhore Nationen. Direktoriets frie
 							Bopæl kan altsaa ikke komme i Beregning. Men hvad der vel fra den anden
 							Side kunde komme til Beregning under Monarkernes Emolumenter, er deres
 							mange Lystslotte, hvis Vedligeholdelse koster Nationerne betydelige
@@ -26958,7 +26958,7 @@ Ptj  rettet s. 2-4-182-263-369-370-546-547-548-553-562-566-589-
                             <speaker xml:id="idm140167174841888">
                                 <hi rend="italics" xml:id="idm140167174841632"><!--<emph>-->Skjønhed.<!--</emph>--></hi>
                             </speaker>
-                            <p xml:id="idm140167174840496">Et Fruentimmer med manne Penge. <hi rend="italics" xml:id="idm140167174840192"><!--<emph>-->Himmelsk Skjønhed<!--</emph>--></hi> er det samme som <hi rend="italics" xml:id="idm140167174839168"><!--<emph>-->en underjordisk<!--</emph>--></hi> Skjonhed, eftersom Buggesen har dekreteret: <hi rend="italics" xml:id="idm140167174838064"><!--<emph>-->at Himlen er ej mere over Jorden.<!--</emph>--></hi>
+                            <p xml:id="idm140167174840496">Et Fruentimmer med manne Penge. <hi rend="italics" xml:id="idm140167174840192"><!--<emph>-->Himmelsk Skjønhed<!--</emph>--></hi> er det samme som <hi rend="italics" xml:id="idm140167174839168"><!--<emph>-->en underjordisk<!--</emph>--></hi> Skjønhed, eftersom Buggesen har dekreteret: <hi rend="italics" xml:id="idm140167174838064"><!--<emph>-->at Himlen er ej mere over Jorden.<!--</emph>--></hi>
                             </p>
                         </sp>
                         <sp xml:id="idm140167174836784">


### PR DESCRIPTION
…bmager-Gade'